### PR TITLE
Create or update flow definitions and schedules

### DIFF
--- a/akka/src/main/scala/com/flowtick/sysiphos/execution/CronScheduler.scala
+++ b/akka/src/main/scala/com/flowtick/sysiphos/execution/CronScheduler.scala
@@ -2,8 +2,7 @@ package com.flowtick.sysiphos.execution
 
 import java.time.{ LocalDateTime, ZoneOffset }
 
-import com.flowtick.sysiphos._
-import com.flowtick.sysiphos.scheduler.{ CronSchedule, FlowSchedule, FlowScheduler }
+import com.flowtick.sysiphos.scheduler.{ FlowSchedule, FlowScheduler }
 import cron4s.Cron
 import cron4s.lib.javatime._
 
@@ -12,10 +11,10 @@ object CronScheduler extends FlowScheduler with Logging {
 
   def toDateTime(epoch: Long): LocalDateTime = LocalDateTime.ofEpochSecond(epoch, 0, offset)
 
-  override def nextOccurrence(schedule: FlowSchedule, now: Long): Option[Long] = schedule match {
-    case cron: CronSchedule =>
-      val dateTime = toDateTime(now)
-      Cron(cron.expression).toOption.flatMap(_.next(dateTime)).map(_.toEpochSecond(offset))
-    case _ => None
+  override def nextOccurrence(schedule: FlowSchedule, now: Long): Option[Long] = {
+    schedule.expression
+      .flatMap(Cron(_).toOption)
+      .flatMap(_.next(toDateTime(now)))
+      .map(_.toEpochSecond(offset))
   }
 }

--- a/akka/src/main/scala/com/flowtick/sysiphos/execution/CronScheduler.scala
+++ b/akka/src/main/scala/com/flowtick/sysiphos/execution/CronScheduler.scala
@@ -6,6 +6,8 @@ import com.flowtick.sysiphos.scheduler.{ FlowSchedule, FlowScheduler }
 import cron4s.Cron
 import cron4s.lib.javatime._
 
+import com.flowtick.sysiphos._
+
 object CronScheduler extends FlowScheduler with Logging {
   val offset: ZoneOffset = ZoneOffset.UTC
 

--- a/akka/src/main/scala/com/flowtick/sysiphos/execution/FlowExecutorActor.scala
+++ b/akka/src/main/scala/com/flowtick/sysiphos/execution/FlowExecutorActor.scala
@@ -36,7 +36,7 @@ trait FlowExecution extends Logging {
   def dueTaskInstances(now: Long): Future[Seq[Option[FlowInstance]]] = {
     log.debug("tick.")
     val futureEnabledSchedules: Future[Seq[FlowSchedule]] = flowScheduleRepository
-      .getFlowSchedules(onlyEnabled = true)
+      .getFlowSchedules(onlyEnabled = true, None)
 
     futureEnabledSchedules.flatMap { schedules =>
       log.debug(s"checking schedules: $schedules.")

--- a/akka/src/test/scala/com/flowtick/sysiphos/execution/AkkaFlowExecutionSpec.scala
+++ b/akka/src/test/scala/com/flowtick/sysiphos/execution/AkkaFlowExecutionSpec.scala
@@ -39,7 +39,7 @@ class AkkaFlowExecutionSpec extends FlatSpec with FlowExecution with Matchers wi
       enabled = Some(true), created = 0, updated = None, creator = "test", version = 0)
     val futureSchedules = Future.successful(Seq(testSchedule))
 
-    (flowScheduleRepository.getFlowSchedules()(_: RepositoryContext)).expects(*).returning(futureSchedules)
+    (flowScheduleRepository.getFlowSchedules(_: Boolean, _: Option[String])(_: RepositoryContext)).expects(*, *, *).returning(futureSchedules)
     (flowScheduler.nextOccurrence _).expects(testSchedule, 0).returning(Some(1))
     (flowScheduleStateStore.setDueDate(_: String, _: Long)(_: RepositoryContext)).expects(testSchedule.id, 1, *)
 

--- a/akka/src/test/scala/com/flowtick/sysiphos/execution/AkkaFlowExecutionSpec.scala
+++ b/akka/src/test/scala/com/flowtick/sysiphos/execution/AkkaFlowExecutionSpec.scala
@@ -29,7 +29,27 @@ class AkkaFlowExecutionSpec extends FlatSpec with FlowExecution with Matchers wi
     nextDueDate: Option[Long],
     enabled: Option[Boolean]) extends FlowSchedule
 
+  final case class TestInstance(
+    id: String,
+    flowDefinitionId: String,
+    creationTime: Long,
+    startTime: Option[Long],
+    endTime: Option[Long],
+    status: String,
+    retries: Int,
+    context: Map[String, String]) extends FlowInstance
+
   "Akka flow executor" should "create child actors for due schedules" in new RepositoryContext {
+    val testInstance = TestInstance(
+      id = "test-instance",
+      flowDefinitionId = "flow-id",
+      creationTime = 0,
+      startTime = None,
+      endTime = None,
+      status = "new",
+      retries = 3,
+      context = Map.empty)
+
     val testSchedule = FlowScheduleDetails(
       id = "test-schedule",
       expression = Some("0 1 * * *"), // daily at 1:00 am
@@ -40,6 +60,7 @@ class AkkaFlowExecutionSpec extends FlatSpec with FlowExecution with Matchers wi
     val futureSchedules = Future.successful(Seq(testSchedule))
 
     (flowScheduleRepository.getFlowSchedules(_: Boolean, _: Option[String])(_: RepositoryContext)).expects(*, *, *).returning(futureSchedules)
+    (flowInstanceRepository.createFlowInstance(_: String, _: Map[String, String])(_: RepositoryContext)).expects("flow-id", Map.empty[String, String], *).returning(Future.successful(testInstance))
     (flowScheduler.nextOccurrence _).expects(testSchedule, 0).returning(Some(1))
     (flowScheduleStateStore.setDueDate(_: String, _: Long)(_: RepositoryContext)).expects(testSchedule.id, 1, *)
 

--- a/akka/src/test/scala/com/flowtick/sysiphos/execution/AkkaFlowExecutionSpec.scala
+++ b/akka/src/test/scala/com/flowtick/sysiphos/execution/AkkaFlowExecutionSpec.scala
@@ -13,7 +13,7 @@ class AkkaFlowExecutionSpec extends FlatSpec with FlowExecution with Matchers wi
   with ScalaFutures with IntegrationPatience {
 
   override val flowInstanceRepository: FlowInstanceRepository[FlowInstance] = mock[FlowInstanceRepository[FlowInstance]]
-  override val flowScheduleRepository: FlowScheduleRepository[FlowSchedule] = mock[FlowScheduleRepository[FlowSchedule]]
+  override val flowScheduleRepository: FlowScheduleRepository = mock[FlowScheduleRepository]
   override val flowScheduler: FlowScheduler = mock[FlowScheduler]
   override val flowScheduleStateStore: FlowScheduleStateStore = mock[FlowScheduleStateStore]
 
@@ -23,20 +23,20 @@ class AkkaFlowExecutionSpec extends FlatSpec with FlowExecution with Matchers wi
 
   final case class TestSchedule(
     id: String,
-    expression: String,
+    expression: Option[String],
     flowDefinitionId: String,
     flowTaskId: Option[String],
     nextDueDate: Option[Long],
-    enabled: Option[Boolean]) extends CronSchedule
+    enabled: Option[Boolean]) extends FlowSchedule
 
   "Akka flow executor" should "create child actors for due schedules" in new RepositoryContext {
-    val testSchedule = TestSchedule(
+    val testSchedule = FlowScheduleDetails(
       id = "test-schedule",
-      expression = "0 1 * * *", // daily at 1:00 am
+      expression = Some("0 1 * * *"), // daily at 1:00 am
       flowDefinitionId = "flow-id",
       flowTaskId = None,
       nextDueDate = None,
-      enabled = Some(true))
+      enabled = Some(true), created = 0, updated = None, creator = "test", version = 0)
     val futureSchedules = Future.successful(Seq(testSchedule))
 
     (flowScheduleRepository.getFlowSchedules()(_: RepositoryContext)).expects(*).returning(futureSchedules)

--- a/akka/src/test/scala/com/flowtick/sysiphos/execution/CronSchedulerSpec.scala
+++ b/akka/src/test/scala/com/flowtick/sysiphos/execution/CronSchedulerSpec.scala
@@ -1,12 +1,12 @@
 package com.flowtick.sysiphos.execution
 
-import com.flowtick.sysiphos.scheduler.CronSchedule
-import org.scalatest.{ FlatSpec, Matchers }
+import com.flowtick.sysiphos.scheduler.FlowSchedule
+import org.scalatest.{FlatSpec, Matchers}
 
 class CronSchedulerSpec extends FlatSpec with Matchers {
   "Cron Scheduler" should "give next occurrence for cron schedule" in {
-    val testSchedule = new CronSchedule {
-      override def expression: String = "10-35 2,4,6 * ? * *"
+    val testSchedule = new FlowSchedule {
+      override def expression: Option[String] = Some("10-35 2,4,6 * ? * *")
 
       override def id: String = "test-schedule"
 

--- a/akka/src/test/scala/com/flowtick/sysiphos/execution/CronSchedulerSpec.scala
+++ b/akka/src/test/scala/com/flowtick/sysiphos/execution/CronSchedulerSpec.scala
@@ -1,7 +1,7 @@
 package com.flowtick.sysiphos.execution
 
 import com.flowtick.sysiphos.scheduler.FlowSchedule
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{ FlatSpec, Matchers }
 
 class CronSchedulerSpec extends FlatSpec with Matchers {
   "Cron Scheduler" should "give next occurrence for cron schedule" in {

--- a/build.sbt
+++ b/build.sbt
@@ -140,6 +140,7 @@ lazy val serverJS = server.js.settings(
   artifactPath in (Compile, fullOptJS) := (artifactPath in (Compile, fastOptJS)).value,
   libraryDependencies ++= Seq(
     "com.thoughtworks.binding" %%% "dom" % "latest.release",
+    "com.thoughtworks.binding" %%% "futurebinding" % "latest.release",
     "org.scala-js" %%% "scalajs-dom" % "0.9.2",
     "be.doeraene" %%% "scalajs-jquery" % "0.9.3",
     "com.flowtick" %%% "pages" % "0.1.5"

--- a/core/shared/src/main/scala/com/flowtick/sysiphos/flow/FlowDefinition.scala
+++ b/core/shared/src/main/scala/com/flowtick/sysiphos/flow/FlowDefinition.scala
@@ -48,7 +48,8 @@ object FlowDefinition {
         "type" -> Json.fromString("shell"),
         "command" -> Json.fromString(cmd.command),
         "children" -> cmd.children.asJson)
-      case _ => Json.Null
+      case task: SysiphosTask => task.asJson
+      case _ => Json.obj()
     }
   }
 

--- a/core/shared/src/main/scala/com/flowtick/sysiphos/flow/FlowDefinitionRepository.scala
+++ b/core/shared/src/main/scala/com/flowtick/sysiphos/flow/FlowDefinitionRepository.scala
@@ -7,7 +7,7 @@ import scala.concurrent.Future
 final case class FlowDefinitionDetails(id: String, version: Option[Long], source: Option[String], created: Option[Long])
 
 trait FlowDefinitionRepository {
-  def addFlowDefinition(flowDefinition: FlowDefinition)(implicit repositoryContext: RepositoryContext): Future[FlowDefinitionDetails]
+  def createOrUpdateFlowDefinition(flowDefinition: FlowDefinition)(implicit repositoryContext: RepositoryContext): Future[FlowDefinitionDetails]
   def getFlowDefinitions(implicit repositoryContext: RepositoryContext): Future[Seq[FlowDefinitionDetails]]
   def findById(id: String)(implicit repositoryContext: RepositoryContext): Future[Option[FlowDefinitionDetails]]
 }

--- a/core/shared/src/main/scala/com/flowtick/sysiphos/scheduler/FlowSchedule.scala
+++ b/core/shared/src/main/scala/com/flowtick/sysiphos/scheduler/FlowSchedule.scala
@@ -6,8 +6,17 @@ trait FlowSchedule {
   def flowTaskId: Option[String]
   def nextDueDate: Option[Long]
   def enabled: Option[Boolean]
+  def expression: Option[String]
 }
 
-trait CronSchedule extends FlowSchedule {
-  def expression: String
-}
+final case class FlowScheduleDetails(
+  id: String,
+  creator: String,
+  created: Long,
+  version: Long,
+  updated: Option[Long],
+  expression: Option[String],
+  flowDefinitionId: String,
+  flowTaskId: Option[String],
+  nextDueDate: Option[Long],
+  enabled: Option[Boolean]) extends FlowSchedule

--- a/core/shared/src/main/scala/com/flowtick/sysiphos/scheduler/FlowScheduleRepository.scala
+++ b/core/shared/src/main/scala/com/flowtick/sysiphos/scheduler/FlowScheduleRepository.scala
@@ -4,15 +4,20 @@ import com.flowtick.sysiphos.core.RepositoryContext
 
 import scala.concurrent.Future
 
-trait FlowScheduleRepository[+T <: FlowSchedule] {
-  def addFlowSchedule(
-    id: String,
-    expression: String,
+trait FlowScheduleRepository {
+  def createFlowSchedule(
+    id: Option[String],
+    expression: Option[String],
     flowDefinitionId: String,
     flowTaskId: Option[String],
-    nextDueDate: Option[Long],
-    enabled: Option[Boolean])(implicit repositoryContext: RepositoryContext): Future[T]
-  def getFlowSchedules()(implicit repositoryContext: RepositoryContext): Future[Seq[T]]
+    enabled: Option[Boolean])(implicit repositoryContext: RepositoryContext): Future[FlowScheduleDetails]
+
+  def updateFlowSchedule(
+    id: String,
+    expression: Option[String],
+    enabled: Option[Boolean])(implicit repositoryContext: RepositoryContext): Future[FlowScheduleDetails]
+
+  def getFlowSchedules(onlyEnabled: Boolean)(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]]
 }
 
 trait FlowScheduleStateStore {

--- a/core/shared/src/main/scala/com/flowtick/sysiphos/scheduler/FlowScheduleRepository.scala
+++ b/core/shared/src/main/scala/com/flowtick/sysiphos/scheduler/FlowScheduleRepository.scala
@@ -17,7 +17,9 @@ trait FlowScheduleRepository {
     expression: Option[String],
     enabled: Option[Boolean])(implicit repositoryContext: RepositoryContext): Future[FlowScheduleDetails]
 
-  def getFlowSchedules(onlyEnabled: Boolean)(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]]
+  def getFlowSchedules(
+    onlyEnabled: Boolean,
+    flowId: Option[String])(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]]
 }
 
 trait FlowScheduleStateStore {

--- a/git/src/main/scala/com/flowtick/sysiphos/git/GitFlowDefinitionRepository.scala
+++ b/git/src/main/scala/com/flowtick/sysiphos/git/GitFlowDefinitionRepository.scala
@@ -20,7 +20,7 @@ class GitFlowDefinitionRepository(
   override def getFlowDefinitions(implicit repositoryContext: RepositoryContext): Future[Seq[FlowDefinitionDetails]] =
     list.map(definitions => definitions.map(definition => FlowDefinitionDetails(definition.id, None, None, None)))
 
-  override def addFlowDefinition(flowDefinition: FlowDefinition)(implicit repositoryContext: RepositoryContext): Future[FlowDefinitionDetails] =
+  override def createOrUpdateFlowDefinition(flowDefinition: FlowDefinition)(implicit repositoryContext: RepositoryContext): Future[FlowDefinitionDetails] =
     add(flowDefinition, s"${flowDefinition.id}.json").map(definition => FlowDefinitionDetails(definition.id, None, None, None))
 
   override def findById(id: String)(implicit repositoryContext: RepositoryContext): Future[Option[FlowDefinitionDetails]] =

--- a/git/src/main/scala/com/flowtick/sysiphos/git/GitFlowScheduleRepository.scala
+++ b/git/src/main/scala/com/flowtick/sysiphos/git/GitFlowScheduleRepository.scala
@@ -20,8 +20,10 @@ class GitFlowScheduleRepository(
   identityFilePassphrase: Option[String] = None)
   extends AbstractGitRepository[FlowScheduleDetails](
     baseDir, remoteUrl, ref, username, password, identityFilePath, identityFilePassphrase) with FlowScheduleRepository {
-  override def getFlowSchedules(onlyEnabled: Boolean)(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]] =
-    list.map(schedules => if (onlyEnabled) schedules.filter(_.enabled.contains(true)) else schedules)
+  override def getFlowSchedules(onlyEnabled: Boolean, flowId: Option[String])(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]] =
+    list.map(schedules => {
+      (if (onlyEnabled) schedules.filter(_.enabled.contains(true)) else schedules).filter(schedule => flowId.forall(_ == schedule.flowDefinitionId))
+    })
 
   def createFlowSchedule(
     id: Option[String],

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/ExecutionsComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/ExecutionsComponent.scala
@@ -1,76 +1,54 @@
 package com.flowtick.sysiphos.ui
 
-import com.flowtick.sysiphos.flow.{ FlowDefinitionSummary, InstanceCount }
+import com.flowtick.sysiphos.flow.FlowDefinitionSummary
 import com.flowtick.sysiphos.ui.vendor.ToastrSupport._
-import com.thoughtworks.binding.Binding.{ Constants, Vars }
+import com.thoughtworks.binding.Binding.Vars
 import com.thoughtworks.binding.{ Binding, dom }
-import org.scalajs.dom.html.{ Button, Div, Table, TableRow }
+import org.scalajs.dom.html.{ Div, Table, TableRow }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ExecutionsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout {
-  val flows: Vars[FlowDefinitionSummary] = Vars.empty[FlowDefinitionSummary]
+  val executions: Vars[FlowDefinitionSummary] = Vars.empty[FlowDefinitionSummary]
 
-  def loadDefinitions(): Unit = sysiphosApi.getFlowDefinitions.notifyError.foreach { response =>
-    flows.value.clear()
-    flows.value.append(response.data.definitions: _*)
+  def loadExecutions(): Unit = Binding {
+    sysiphosApi.getFlowDefinitions.notifyError.foreach { response =>
+      executions.value.clear()
+      executions.value.append(response.data.definitions: _*)
+    }
+    executions
   }
 
-  override def init(): Unit = loadDefinitions()
+  override def init(): Unit = loadExecutions()
 
   @dom
-  def instanceCountButton(count: InstanceCount): Binding[Button] =
-    <button type="button" class={
-      count.status match {
-        case "new" => "btn btn-info"
-        case _ => "btn btn-default"
-      }
-    }><strong>{ count.status }</strong>&nbsp;<span class="badge"> { count.count.toString } </span></button>
-
-  @dom
-  def flowRow(flow: FlowDefinitionSummary): Binding[TableRow] =
+  def executionsRow(flow: FlowDefinitionSummary): Binding[TableRow] =
     <tr>
       <td><a href={ "#/flow/show/" + flow.id }> { flow.id }</a></td>
-      <td>
-        <div class="btn-group" data:role="group" data:aria-label="count-buttons">
-          { Constants(flow.counts: _*).map(instanceCountButton(_).bind) }
-        </div>
-      </td>
-      <td>
-        <button class="btn btn-success"><i class="glyphicon glyphicon-play"></i></button>
-      </td>
     </tr>
 
   @dom
-  def flowTable: Binding[Table] = {
+  def executionsTable: Binding[Table] = {
     <table class="table table-striped">
       <thead>
         <th>ID</th>
-        <th>Recent Executions</th>
         <th>Actions</th>
       </thead>
       <tbody>
         {
-          for (flow <- flows) yield flowRow(flow).bind
+          for (execution <- executions) yield executionsRow(execution).bind
         }
       </tbody>
     </table>
   }
 
   @dom
-  def flowsSection: Binding[Div] = {
-    <div>
-      <h3>Flows <a class="btn btn-default" href="#/flow/new"><i class="fas fa-plus"></i> Add</a> </h3>
-      {
-        flowTable.bind
-      }
-    </div>
-  }
-
-  @dom
   override def element: Binding[Div] =
-    <div>
-      { layout(flowsSection.bind).bind }
+    <div id="executions">
+      <h3>Executions</h3>
+      {
+        executionsTable.bind
+      }
     </div>
 
 }

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/ExecutionsComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/ExecutionsComponent.scala
@@ -8,7 +8,7 @@ import org.scalajs.dom.html.{ Button, Div, Table, TableRow }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class FlowsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout {
+class ExecutionsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout {
   val flows: Vars[FlowDefinitionSummary] = Vars.empty[FlowDefinitionSummary]
 
   def loadDefinitions(): Unit = sysiphosApi.getFlowDefinitions.notifyError.foreach { response =>

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowComponent.scala
@@ -58,7 +58,10 @@ class FlowComponent(id: String, sysiphosApi: SysiphosApi) extends HtmlComponent 
     </div>
 
   def createOrUpdate(source: String): Future[Option[FlowDefinitionDetails]] =
-    sysiphosApi.createOrUpdateFlowDefinition(source).notifyError
+    sysiphosApi
+      .createOrUpdateFlowDefinition(source)
+      .notifyError
+      .successMessage(_ => "Flow updated.")
 
   @dom
   override def element: Binding[Div] = {

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowComponent.scala
@@ -7,7 +7,8 @@ import org.scalajs.dom.Event
 import org.scalajs.dom.html.Div
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Success
+import scala.concurrent.Future
+import scala.util.{ Success }
 
 class FlowComponent(id: Option[String], sysiphosApi: SysiphosApi) extends HtmlComponent with Layout {
   lazy val sourceEditor: AceEditorSupport.Editor = {
@@ -29,13 +30,17 @@ class FlowComponent(id: Option[String], sysiphosApi: SysiphosApi) extends HtmlCo
     </div>
   }
 
+  def loadDefinition: Future[Option[FlowDefinitionDetails]] =
+    if (id.isEmpty)
+      Future.successful(None)
+    else
+      sysiphosApi.getFlowDefinition(id.get)
+
   @dom
   def flowSection(id: Option[String]): Binding[Div] =
     <div>
       {
-        if (id.isEmpty) {
-          empty.bind
-        } else FutureBinding(sysiphosApi.getFlowDefinition(id.get)).bind match {
+        FutureBinding(loadDefinition).bind match {
           case Some(Success(Some(definitionResult))) => flowOverview(definitionResult).bind
           case _ => empty.bind
         }
@@ -88,7 +93,7 @@ class FlowComponent(id: Option[String], sysiphosApi: SysiphosApi) extends HtmlCo
   def empty: Binding[Div] = <div></div>
 
   @dom
-  override val element: Binding[Div] =
+  override def element: Binding[Div] =
     <div>
       { layout(flowSection(id).bind).bind }
     </div>

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowComponent.scala
@@ -3,9 +3,12 @@ import com.flowtick.sysiphos.flow.FlowDefinitionDetails
 import com.flowtick.sysiphos.ui.vendor.AceEditorSupport
 import com.thoughtworks.binding.Binding._
 import com.thoughtworks.binding._
+import org.scalajs.dom.Event
 import org.scalajs.dom.html.Div
+import vendor.ToastrSupport._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class FlowComponent(id: String, sysiphosApi: SysiphosApi) extends HtmlComponent with Layout {
   val flowDefinition: Vars[FlowDefinitionDetails] = Vars.empty[FlowDefinitionDetails]
@@ -51,7 +54,11 @@ class FlowComponent(id: String, sysiphosApi: SysiphosApi) extends HtmlComponent 
           <div id="flow-source" style="height: 300px"></div>
         </div>
       </div>
+      <button class="btn btn-primary" onclick={ (_: Event) => createOrUpdate(sourceEditor.getValue()) }>Save</button>
     </div>
+
+  def createOrUpdate(source: String): Future[Option[FlowDefinitionDetails]] =
+    sysiphosApi.createOrUpdateFlowDefinition(source).notifyError
 
   @dom
   override def element: Binding[Div] = {

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowsComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowsComponent.scala
@@ -9,11 +9,6 @@ import org.scalajs.dom.html.{ Button, Div, Table, TableRow }
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class FlowsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout {
-  sealed trait Action
-  case object Initial extends Action
-  case object Foo extends Action
-  case class SetDefinitions(definitions: Seq[FlowDefinitionSummary]) extends Action
-
   val flows = Vars.empty[FlowDefinitionSummary]
 
   def getDefinitions(): Unit = sysiphosApi.getFlowDefinitions.notifyError.foreach { response =>

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowsComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowsComponent.scala
@@ -9,12 +9,14 @@ import org.scalajs.dom.html.{ Button, Div, Table, TableRow }
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class FlowsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout {
-  val flows = Vars.empty[FlowDefinitionSummary]
+  val flows: Vars[FlowDefinitionSummary] = Vars.empty[FlowDefinitionSummary]
 
-  def getDefinitions(): Unit = sysiphosApi.getFlowDefinitions.notifyError.foreach { response =>
+  def loadDefinitions(): Unit = sysiphosApi.getFlowDefinitions.notifyError.foreach { response =>
     flows.value.clear()
     flows.value.append(response.data.definitions: _*)
   }
+
+  override def init(): Unit = loadDefinitions()
 
   @dom
   def instanceCountButton(count: InstanceCount): Binding[Button] =
@@ -28,7 +30,7 @@ class FlowsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout
   @dom
   def flowRow(flow: FlowDefinitionSummary): Binding[TableRow] =
     <tr>
-      <td><h4><a href={ "#/flow/" + flow.id }> { flow.id }</a></h4></td>
+      <td><a href={ "#/flow/show/" + flow.id }> { flow.id }</a></td>
       <td>
         <div class="btn-group" data:role="group" data:aria-label="count-buttons">
           { Constants(flow.counts: _*).map(instanceCountButton(_).bind) }
@@ -58,7 +60,7 @@ class FlowsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout
   @dom
   def flowsSection: Binding[Div] = {
     <div>
-      <h3>Flows</h3>
+      <h3>Flows <a class="btn btn-default" href="#/flow/new"><i class="fas fa-plus"></i> Add</a> </h3>
       {
         flowTable.bind
       }
@@ -66,10 +68,9 @@ class FlowsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout
   }
 
   @dom
-  override val element: Binding[Div] = {
+  override val element: Binding[Div] =
     <div>
-      { getDefinitions(); layout(flowsSection.bind).bind }
+      { layout(flowsSection.bind).bind }
     </div>
-  }
 
 }

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowsComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/FlowsComponent.scala
@@ -11,12 +11,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class FlowsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout {
   val flows: Vars[FlowDefinitionSummary] = Vars.empty[FlowDefinitionSummary]
 
-  def loadDefinitions(): Unit = sysiphosApi.getFlowDefinitions.notifyError.foreach { response =>
-    flows.value.clear()
-    flows.value.append(response.data.definitions: _*)
-  }
+  def loadDefinitions: Binding[Vars[FlowDefinitionSummary]] = Binding {
+    sysiphosApi.getFlowDefinitions.notifyError.foreach { response =>
+      flows.value.clear()
+      flows.value.append(response.data.definitions: _*)
+    }
 
-  override def init(): Unit = loadDefinitions()
+    flows
+  }
 
   @dom
   def instanceCountButton(count: InstanceCount): Binding[Button] =
@@ -51,26 +53,19 @@ class FlowsComponent(sysiphosApi: SysiphosApi) extends HtmlComponent with Layout
       </thead>
       <tbody>
         {
-          for (flow <- flows) yield flowRow(flow).bind
+          for (flow <- loadDefinitions.bind) yield flowRow(flow).bind
         }
       </tbody>
     </table>
   }
 
   @dom
-  def flowsSection: Binding[Div] = {
-    <div>
+  override def element: Binding[Div] =
+    <div id="flows">
       <h3>Flows <a class="btn btn-default" href="#/flow/new"><i class="fas fa-plus"></i> Add</a> </h3>
       {
         flowTable.bind
       }
-    </div>
-  }
-
-  @dom
-  override def element: Binding[Div] =
-    <div>
-      { layout(flowsSection.bind).bind }
     </div>
 
 }

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/Layout.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/Layout.scala
@@ -6,7 +6,7 @@ import org.scalajs.dom.html.Div
 trait Layout {
   @dom
   def layout(content: Div): Binding[Div] =
-    <div>
+    <div id="layout">
       <nav class="navbar navbar-default navbar-fixed-top">
         <div class="container">
           <div class="navbar-header">

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/Layout.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/Layout.scala
@@ -22,6 +22,7 @@ trait Layout {
           <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
               <li><a href="#/flows">Flows</a></li>
+              <li><a href="#/schedules">Schedules</a></li>
               <li><a target="_blank" href="/graphiql"><i class="fa fa-keyboard" data:aria-hidden="true"></i> API Console</a></li>
             </ul>
           </div><!--/.nav-collapse -->

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/Layout.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/Layout.scala
@@ -21,8 +21,8 @@ trait Layout {
           </div>
           <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="#/flows">Flows</a></li>
-              <li><a href="#/schedules">Schedules</a></li>
+              <li><a href="#/flows"><i class="fas fa-project-diagram"></i> Flows</a></li>
+              <li><a href="#/schedules"><i class="fas fa-clock"></i> Schedules</a></li>
               <li><a target="_blank" href="/graphiql"><i class="fa fa-keyboard" data:aria-hidden="true"></i> API Console</a></li>
             </ul>
           </div><!--/.nav-collapse -->

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/SchedulesComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/SchedulesComponent.scala
@@ -1,0 +1,95 @@
+package com.flowtick.sysiphos.ui
+
+import com.flowtick.sysiphos.scheduler.FlowScheduleDetails
+import com.thoughtworks.binding.Binding.Vars
+import com.thoughtworks.binding.{ Binding, dom }
+import org.scalajs.dom.html.{ Div, Table, TableRow }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import com.flowtick.sysiphos.ui.vendor.ToastrSupport._
+import org.scalajs.dom.raw.{ Event, HTMLInputElement }
+
+import scala.concurrent.Future
+import scala.scalajs.js.Date
+
+class SchedulesComponent(api: SysiphosApi) extends HtmlComponent with Layout {
+  val schedules: Vars[FlowScheduleDetails] = Vars.empty[FlowScheduleDetails]
+
+  def getSchedules(): Unit = api.getSchedules.notifyError.foreach { response =>
+    schedules.value.clear()
+    schedules.value.append(response.data.schedules: _*)
+  }
+
+  def formatDate(epochSeconds: Long): String = {
+    val date = new Date(epochSeconds * 1000)
+    s"${date.toDateString()}, ${date.toTimeString()}"
+  }
+
+  def toggleEnable(id: String, enabled: Boolean): Unit =
+    api
+      .setFlowScheduleEnabled(id, enabled)
+      .notifyError
+      .successMessage(_ => s"$id is now ${if (enabled) "enabled" else "disabled"}")
+      .foreach(_ => getSchedules())
+
+  def setExpression(id: String, expression: String): Unit = {
+    api
+      .setFlowScheduleExpression(id, expression)
+      .notifyError
+      .successMessage(_ => s"$id expression updated: $expression")
+      .foreach(_ => getSchedules())
+  }
+
+  @dom
+  def scheduleRow(schedule: FlowScheduleDetails): Binding[TableRow] =
+    <tr>
+      <td>
+        {
+          if (schedule.enabled.getOrElse(false)) {
+            <button class="btn btn-danger" onclick={ _: Event => toggleEnable(schedule.id, enabled = false) }>Disable</button>
+          } else
+            <button class="btn btn-info" onclick={ _: Event => toggleEnable(schedule.id, enabled = true) }>Enable</button>
+        }
+      </td>
+      <td>{ schedule.id }</td>
+      <td><a href={ "#/flow/" + schedule.flowDefinitionId }> { schedule.flowDefinitionId }</a></td>
+      <td>
+        <input type="text" value={ schedule.expression.getOrElse("") } onblur={ (e: Event) => setExpression(schedule.id, e.target.asInstanceOf[HTMLInputElement].value) }></input>
+      </td>
+      <td>{ schedule.nextDueDate.map(formatDate).getOrElse("N/A") }</td>
+    </tr>
+
+  @dom
+  def schedulesTable: Binding[Table] = {
+    <table class="table table-striped">
+      <thead>
+        <th></th>
+        <th>ID</th>
+        <th>Flow</th>
+        <th>Expression</th>
+        <th>Next Due</th>
+      </thead>
+      <tbody>
+        {
+          for (schedule <- schedules) yield scheduleRow(schedule).bind
+        }
+      </tbody>
+    </table>
+  }
+
+  @dom
+  def schedulesSection: Binding[Div] = {
+    <div>
+      <h3>Schedules</h3>
+      {
+        schedulesTable.bind
+      }
+    </div>
+  }
+
+  @dom
+  override val element: Binding[Div] =
+    <div>
+      { getSchedules(); layout(schedulesSection.bind).bind }
+    </div>
+}

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/SchedulesComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/SchedulesComponent.scala
@@ -1,15 +1,13 @@
 package com.flowtick.sysiphos.ui
 
 import com.flowtick.sysiphos.scheduler.FlowScheduleDetails
+import com.flowtick.sysiphos.ui.vendor.ToastrSupport._
 import com.thoughtworks.binding.Binding.Vars
 import com.thoughtworks.binding.{ Binding, dom }
 import org.scalajs.dom.html.{ Div, Table, TableRow }
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import com.flowtick.sysiphos.ui.vendor.ToastrSupport._
 import org.scalajs.dom.raw.{ Event, HTMLInputElement }
 
-import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.scalajs.js.Date
 
 class SchedulesComponent(api: SysiphosApi) extends HtmlComponent with Layout {
@@ -19,6 +17,8 @@ class SchedulesComponent(api: SysiphosApi) extends HtmlComponent with Layout {
     schedules.value.clear()
     schedules.value.append(response.data.schedules: _*)
   }
+
+  override def init(): Unit = getSchedules()
 
   def formatDate(epochSeconds: Long): String = {
     val date = new Date(epochSeconds * 1000)
@@ -52,7 +52,7 @@ class SchedulesComponent(api: SysiphosApi) extends HtmlComponent with Layout {
         }
       </td>
       <td>{ schedule.id }</td>
-      <td><a href={ "#/flow/" + schedule.flowDefinitionId }> { schedule.flowDefinitionId }</a></td>
+      <td><a href={ "#/flow/show/" + schedule.flowDefinitionId }> { schedule.flowDefinitionId }</a></td>
       <td>
         <input type="text" value={ schedule.expression.getOrElse("") } onblur={ (e: Event) => setExpression(schedule.id, e.target.asInstanceOf[HTMLInputElement].value) }></input>
       </td>
@@ -90,6 +90,6 @@ class SchedulesComponent(api: SysiphosApi) extends HtmlComponent with Layout {
   @dom
   override val element: Binding[Div] =
     <div>
-      { getSchedules(); layout(schedulesSection.bind).bind }
+      { layout(schedulesSection.bind).bind }
     </div>
 }

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosApi.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosApi.scala
@@ -28,7 +28,7 @@ trait SysiphosApi {
 
   def createOrUpdateFlowDefinition(source: String): Future[Option[FlowDefinitionDetails]]
 
-  def getSchedules: Future[GraphQLResponse[FlowScheduleList]]
+  def getSchedules(flowId: Option[String]): Future[GraphQLResponse[FlowScheduleList]]
 
   def setFlowScheduleEnabled(
     id: String,
@@ -61,7 +61,7 @@ class SysiphosApiClient(implicit executionContext: ExecutionContext) extends Sys
     })
   }
 
-  override def getSchedules: Future[GraphQLResponse[FlowScheduleList]] =
+  override def getSchedules(flowId: Option[String]): Future[GraphQLResponse[FlowScheduleList]] =
     query[FlowScheduleList]("{ schedules {id, creator, created, version, flowDefinitionId, enabled, expression, nextDueDate } }")
 
   override def getFlowDefinitions: Future[GraphQLResponse[FlowDefinitionList]] =

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosApi.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosApi.scala
@@ -13,6 +13,8 @@ case class FlowDefinitionDetailsResult(definition: Option[FlowDefinitionDetails]
 case class FlowDefinitionList(definitions: Seq[FlowDefinitionSummary])
 case class FlowScheduleList(schedules: Seq[FlowScheduleDetails])
 
+case class CreateOrUpdateFlowResult[T](createOrUpdateFlowDefinition: T)
+
 case class EnableResult(enabled: Boolean)
 case class ExpressionResult(expression: String)
 case class UpdateFlowScheduleResponse[T](updateFlowSchedule: T)
@@ -79,21 +81,21 @@ class SysiphosApiClient(implicit executionContext: ExecutionContext) extends Sys
                     |  }
                     |}
                     |""".stripMargin
-        query[FlowDefinitionDetailsResult](queryString).map(_.data.definition)
+        query[CreateOrUpdateFlowResult[Option[FlowDefinitionDetails]]](queryString).map(_.data.createOrUpdateFlowDefinition)
       case Left(error) => Future.failed(error)
     }
 
   override def setFlowScheduleEnabled(
     id: String,
     enabled: Boolean): Future[Boolean] = {
-    val queryString = s"""mutation { updateFlowSchedule(id:"$id", enabled: $enabled) { enabled } }"""
+    val queryString = s"""mutation { updateFlowSchedule(id: "$id", enabled: $enabled) { enabled } }"""
     query[UpdateFlowScheduleResponse[EnableResult]](queryString).map(_.data.updateFlowSchedule.enabled)
   }
 
   override def setFlowScheduleExpression(
     id: String,
     expression: String): Future[String] = {
-    val queryString = s"""mutation { updateFlowSchedule(id:"$id", expression: "$expression") { expression } }"""
+    val queryString = s"""mutation { updateFlowSchedule(id: "$id", expression: "$expression") { expression } }"""
     query[UpdateFlowScheduleResponse[ExpressionResult]](queryString).map(_.data.updateFlowSchedule.expression)
   }
 }

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosUI.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosUI.scala
@@ -28,12 +28,13 @@ object SysiphosUI extends App {
 
   val api = new SysiphosApiClient()(ExecutionContext.global)
   val flowsComponent = new FlowsComponent(api)
-  val schedulesComponent = new SchedulesComponent(api)
+  val schedulesComponent = new SchedulesComponent(None, api)
 
   page[Binding[Div]]("/flows", _ => flowsComponent)
     .page("/flow/show/:id", ctx => new FlowComponent(ctx.pathParams.get("id"), api))
     .page("/flow/new", _ => new FlowComponent(None, api))
     .page("/schedules", _ => schedulesComponent)
+    .page("/schedules/show/:flowId", ctx => new SchedulesComponent(ctx.pathParams.get("flowId"), api))
     .otherwise(_ => new WelcomeComponent)
     .view(domView)
 

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosUI.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosUI.scala
@@ -28,9 +28,11 @@ object SysiphosUI extends App {
 
   val api = new SysiphosApiClient()(ExecutionContext.global)
   val flowsComponent = new FlowsComponent(api)
+  val schedulesComponent = new SchedulesComponent(api)
 
   page[Binding[Div]]("/flows", _ => flowsComponent)
     .page("/flow/:id", ctx => ctx.pathParams.get("id").map(new FlowComponent(_, api)).getOrElse(new WelcomeComponent))
+    .page("/schedules", _ => schedulesComponent)
     .otherwise(_ => new WelcomeComponent)
     .view(domView)
 

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosUI.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosUI.scala
@@ -3,9 +3,9 @@ package com.flowtick.sysiphos.ui
 import com.thoughtworks.binding.Binding.Vars
 import com.thoughtworks.binding.{ Binding, dom }
 import org.scalajs.dom.html.Div
-import org.scalajs.dom.window
-import pages.DomView
-import pages.Page.{ Component, page }
+import org.scalajs.dom.{ Event, HashChangeEvent, window }
+import pages.{ DomView, Page }
+import pages.Page.{ Component, Routing, View, page }
 
 import scala.concurrent.ExecutionContext
 
@@ -31,10 +31,11 @@ object SysiphosUI extends App {
   val schedulesComponent = new SchedulesComponent(api)
 
   page[Binding[Div]]("/flows", _ => flowsComponent)
-    .page("/flow/:id", ctx => ctx.pathParams.get("id").map(new FlowComponent(_, api)).getOrElse(new WelcomeComponent))
+    .page("/flow/show/:id", ctx => new FlowComponent(ctx.pathParams.get("id"), api))
+    .page("/flow/new", _ => new FlowComponent(None, api))
     .page("/schedules", _ => schedulesComponent)
     .otherwise(_ => new WelcomeComponent)
     .view(domView)
 
-  dom.render(window.document.getElementById("sysiphos-app"), appView)
+  com.thoughtworks.binding.dom.render(window.document.getElementById("sysiphos-app"), appView)
 }

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosUI.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/SysiphosUI.scala
@@ -9,7 +9,7 @@ import pages.Page.{ Component, Routing, View, page }
 
 import scala.concurrent.ExecutionContext
 
-object SysiphosUI extends App {
+object SysiphosUI extends App with Layout {
   case class DomComponent(element: Binding[Div]) extends Component[Binding[Div]]
 
   val currentView = Vars.empty[Binding[Div]]
@@ -17,7 +17,7 @@ object SysiphosUI extends App {
   @dom
   def appView: Binding[Div] = {
     <div id="app-view">
-      { for (view <- currentView) yield view.bind }
+      { for (view <- currentView) yield layout(view.bind).bind }
     </div>
   }
 

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/WelcomeComponent.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/WelcomeComponent.scala
@@ -13,6 +13,6 @@ class WelcomeComponent extends HtmlComponent with Layout {
   @dom
   override val element: Binding[Div] =
     <div>
-      { layout(welcomeMessage.bind).bind }
+      { welcomeMessage.bind }
     </div>
 }

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/vendor/AceEditorSupport.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/vendor/AceEditorSupport.scala
@@ -8,9 +8,10 @@ import scala.scalajs.js.annotation.JSGlobal
 object AceEditorSupport extends js.Any {
   @js.native
   trait Editor extends js.Any {
-    def setValue(value: String, pos: Int = 0): js.native
+    def getValue(): String = js.native
+    def setValue(value: String, pos: Int = 0): Unit = js.native
     def resize(): Unit = js.native
-    def setTheme(theme: String): js.native
+    def setTheme(theme: String): Unit = js.native
     def session: Session = js.native
   }
 

--- a/server/js/src/main/scala/com/flowtick/sysiphos/ui/vendor/ToastrSupport.scala
+++ b/server/js/src/main/scala/com/flowtick/sysiphos/ui/vendor/ToastrSupport.scala
@@ -15,7 +15,7 @@ object ToastrSupport {
         case Success(value) =>
           successMessage.map(_(value)).foreach(message => Toastr.success(message))
         case Failure(error) =>
-          errorMessage.map(_(error)).foreach(message => Toastr.error(message))
+          errorMessage.map(_(error)).foreach(message => Toastr.error(message.take(1024)))
       }
 
     def errorMessage(message: Throwable => String): Future[T] = withMessages(None, Some(message))

--- a/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApi.scala
+++ b/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApi.scala
@@ -32,7 +32,7 @@ object SysiphosApi {
 
   trait ApiMutationContext {
     @GraphQLField
-    def foo = "bar"
+    def createOrUpdate(json: String): Future[FlowDefinitionDetails]
   }
 
   trait ApiContext extends ApiQueryContext with ApiMutationContext

--- a/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApi.scala
+++ b/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApi.scala
@@ -30,7 +30,7 @@ object SysiphosApi {
     def definition(id: String): Future[Option[FlowDefinitionDetails]]
 
     @GraphQLField
-    def schedules(id: Option[String]): Future[Seq[FlowScheduleDetails]]
+    def schedules(id: Option[String], flowId: Option[String]): Future[Seq[FlowScheduleDetails]]
   }
 
   trait ApiMutationContext {

--- a/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApiContext.scala
+++ b/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApiContext.scala
@@ -13,8 +13,8 @@ class SysiphosApiContext(
   val flowInstanceRepository: FlowInstanceRepository[FlowInstance],
   val flowScheduleStateStore: FlowScheduleStateStore)(implicit executionContext: ExecutionContext, repositoryContext: RepositoryContext)
   extends ApiContext {
-  override def schedules(id: Option[String]): Future[Seq[FlowScheduleDetails]] =
-    flowScheduleRepository.getFlowSchedules(onlyEnabled = false).map(_.filter(schedule => id.forall(_ == schedule.id)))
+  override def schedules(id: Option[String], flowId: Option[String]): Future[Seq[FlowScheduleDetails]] =
+    flowScheduleRepository.getFlowSchedules(onlyEnabled = false, flowId).map(_.filter(schedule => id.forall(_ == schedule.id)))
 
   override def definitions(id: Option[String]): Future[Seq[FlowDefinitionSummary]] =
     for {

--- a/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApiContext.scala
+++ b/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApiContext.scala
@@ -28,4 +28,11 @@ class SysiphosApiContext(
 
   override def definition(id: String): Future[Option[FlowDefinitionDetails]] =
     flowDefinitionRepository.findById(id)
+
+  override def createOrUpdate(source: String): Future[FlowDefinitionDetails] =
+    FlowDefinition.fromJson(source) match {
+      case Right(definition) =>
+        flowDefinitionRepository.createOrUpdateFlowDefinition(definition)
+      case Left(error) => Future.failed(error)
+    }
 }

--- a/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApiContext.scala
+++ b/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApiContext.scala
@@ -3,18 +3,19 @@ package com.flowtick.sysiphos.api
 import com.flowtick.sysiphos.api.SysiphosApi.ApiContext
 import com.flowtick.sysiphos.core.RepositoryContext
 import com.flowtick.sysiphos.flow._
-import com.flowtick.sysiphos.scheduler.{ FlowSchedule, FlowScheduleRepository, FlowScheduleStateStore }
+import com.flowtick.sysiphos.scheduler.{ FlowScheduleDetails, FlowScheduleRepository, FlowScheduleStateStore }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 class SysiphosApiContext(
   val flowDefinitionRepository: FlowDefinitionRepository,
-  val flowScheduleRepository: FlowScheduleRepository[FlowSchedule],
+  val flowScheduleRepository: FlowScheduleRepository,
   val flowInstanceRepository: FlowInstanceRepository[FlowInstance],
   val flowScheduleStateStore: FlowScheduleStateStore)(implicit executionContext: ExecutionContext, repositoryContext: RepositoryContext)
   extends ApiContext {
-  override def schedules(id: Option[String]): Future[Seq[FlowSchedule]] =
-    flowScheduleRepository.getFlowSchedules.map(_.filter(schedule => id.forall(_ == schedule.id)))
+  override def schedules(id: Option[String]): Future[Seq[FlowScheduleDetails]] =
+    flowScheduleRepository.getFlowSchedules(onlyEnabled = false).map(_.filter(schedule => id.forall(_ == schedule.id)))
+
   override def definitions(id: Option[String]): Future[Seq[FlowDefinitionSummary]] =
     for {
       definitions <- flowDefinitionRepository.getFlowDefinitions.map(_.filter(definitionDetails => id.forall(_ == definitionDetails.id)))
@@ -29,10 +30,35 @@ class SysiphosApiContext(
   override def definition(id: String): Future[Option[FlowDefinitionDetails]] =
     flowDefinitionRepository.findById(id)
 
-  override def createOrUpdate(source: String): Future[FlowDefinitionDetails] =
+  override def createOrUpdateFlowDefinition(source: String): Future[FlowDefinitionDetails] =
     FlowDefinition.fromJson(source) match {
       case Right(definition) =>
         flowDefinitionRepository.createOrUpdateFlowDefinition(definition)
       case Left(error) => Future.failed(error)
     }
+
+  override def createFlowSchedule(
+    id: Option[String],
+    flowDefinitionId: String,
+    flowTaskId: Option[String],
+    expression: Option[String],
+    enabled: Option[Boolean]): Future[FlowScheduleDetails] = {
+    flowScheduleRepository.createFlowSchedule(
+      id,
+      expression,
+      flowDefinitionId,
+      flowTaskId,
+      enabled)
+  }
+
+  override def setDueDate(flowScheduleId: String, dueDate: Long): Future[Boolean] = {
+    flowScheduleStateStore.setDueDate(flowScheduleId, dueDate).map(_ => true)
+  }
+
+  override def updateFlowSchedule(
+    id: String,
+    expression: Option[String],
+    enabled: Option[Boolean]): Future[FlowScheduleDetails] = {
+    flowScheduleRepository.updateFlowSchedule(id, expression, enabled)
+  }
 }

--- a/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApiServer.scala
+++ b/server/jvm/src/main/scala/com/flowtick/sysiphos/api/SysiphosApiServer.scala
@@ -31,7 +31,7 @@ trait SysiphosApiServer extends SysiphosApi
   implicit def scheduler: Scheduler
 
   def startExecutorSystem(
-    flowScheduleRepository: FlowScheduleRepository[FlowSchedule],
+    flowScheduleRepository: FlowScheduleRepository,
     flowInstanceRepository: FlowInstanceRepository[FlowInstance],
     flowScheduleStateStore: FlowScheduleStateStore,
     flowDefinitionRepository: FlowDefinitionRepository): Unit = {

--- a/server/jvm/src/test/scala/com/flowtick/sysiphos/api/DevSysiphosApiServer.scala
+++ b/server/jvm/src/test/scala/com/flowtick/sysiphos/api/DevSysiphosApiServer.scala
@@ -1,6 +1,5 @@
 package com.flowtick.sysiphos.api
 
-import java.time.{ LocalDateTime, ZoneOffset }
 import java.util.concurrent.Executors
 
 import akka.actor.ActorSystem
@@ -35,20 +34,20 @@ object DevSysiphosApiServer extends App with SysiphosApiServer with ScalaFutures
   }
 
   Try {
-  val definitionDetails = flowDefinitionRepository.createOrUpdateFlowDefinition(SysiphosDefinition(
-    "foo",
-    CommandLineTask("foo", None, "ls -la"))).futureValue
+    val definitionDetails = flowDefinitionRepository.createOrUpdateFlowDefinition(SysiphosDefinition(
+      "foo",
+      CommandLineTask("foo", None, "ls -la"))).futureValue
 
-  val definitionDetails2 = flowDefinitionRepository.createOrUpdateFlowDefinition(SysiphosDefinition(
-    "foo2",
-    CommandLineTask("foo", None, "ls -la"))).futureValue
+    val definitionDetails2 = flowDefinitionRepository.createOrUpdateFlowDefinition(SysiphosDefinition(
+      "foo2",
+      CommandLineTask("foo", None, "ls -la"))).futureValue
 
-  flowScheduleRepository.createFlowSchedule(
-    Some("test-schedule"),
-    Some("0,15,30,45 * * ? * *"),
-    definitionDetails.id,
-    None,
-    Some(true)).futureValue
+    flowScheduleRepository.createFlowSchedule(
+      Some("test-schedule"),
+      Some("0,15,30,45 * * ? * *"),
+      definitionDetails.id,
+      None,
+      Some(true)).futureValue
   }
 
   startExecutorSystem(flowScheduleRepository, flowInstanceRepository, flowScheduleRepository, flowDefinitionRepository)

--- a/server/jvm/src/test/scala/com/flowtick/sysiphos/api/DevSysiphosApiServer.scala
+++ b/server/jvm/src/test/scala/com/flowtick/sysiphos/api/DevSysiphosApiServer.scala
@@ -33,11 +33,11 @@ object DevSysiphosApiServer extends App with SysiphosApiServer with ScalaFutures
     override def currentUser: String = "dev-test"
   }
 
-  val definitionDetails = flowDefinitionRepository.addFlowDefinition(SysiphosDefinition(
+  val definitionDetails = flowDefinitionRepository.createOrUpdateFlowDefinition(SysiphosDefinition(
     "foo",
     CommandLineTask("foo", None, "ls -la"))).futureValue
 
-  val definitionDetails2 = flowDefinitionRepository.addFlowDefinition(SysiphosDefinition(
+  val definitionDetails2 = flowDefinitionRepository.createOrUpdateFlowDefinition(SysiphosDefinition(
     "foo2",
     CommandLineTask("foo", None, "ls -la"))).futureValue
 

--- a/server/jvm/src/test/scala/com/flowtick/sysiphos/api/DevSysiphosApiServer.scala
+++ b/server/jvm/src/test/scala/com/flowtick/sysiphos/api/DevSysiphosApiServer.scala
@@ -41,12 +41,11 @@ object DevSysiphosApiServer extends App with SysiphosApiServer with ScalaFutures
     "foo2",
     CommandLineTask("foo", None, "ls -la"))).futureValue
 
-  flowScheduleRepository.addFlowSchedule(
-    "test-schedule",
-    "0,15,30,45 * * ? * *",
+  flowScheduleRepository.createFlowSchedule(
+    Some("test-schedule"),
+    Some("0,15,30,45 * * ? * *"),
     definitionDetails.id,
     None,
-    Some(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)),
     Some(true)).futureValue
 
   startExecutorSystem(flowScheduleRepository, flowInstanceRepository, flowScheduleRepository, flowDefinitionRepository)

--- a/slick/src/main/resources/db/create_flow_schedule.xml
+++ b/slick/src/main/resources/db/create_flow_schedule.xml
@@ -32,7 +32,7 @@
                 <constraints nullable="true"/>
             </column>
             <column name="_EXPRESSION" type="varchar(255)">
-                <constraints nullable="false"/>
+                <constraints nullable="true"/>
             </column>
 
             <column name="_VERSION" type="bigint">

--- a/slick/src/main/scala/com/flowtick/sysiphos/slick/SlickFlowDefinitionRepository.scala
+++ b/slick/src/main/scala/com/flowtick/sysiphos/slick/SlickFlowDefinitionRepository.scala
@@ -38,8 +38,8 @@ class SlickFlowDefinitionRepository(dataSource: DataSource)(implicit val profile
 
   private val flowDefinitionTable = TableQuery[FlowDefinitions]
 
-  override def addFlowDefinition(flowDefinition: FlowDefinition)(implicit repositoryContext: RepositoryContext): Future[FlowDefinitionDetails] = {
-    val newDefinition = SlickFlowDefinition(
+  override def createOrUpdateFlowDefinition(flowDefinition: FlowDefinition)(implicit repositoryContext: RepositoryContext): Future[FlowDefinitionDetails] = {
+    val slickDefinition = SlickFlowDefinition(
       id = flowDefinition.id,
       json = FlowDefinition.toJson(flowDefinition),
       version = 0L,
@@ -47,11 +47,20 @@ class SlickFlowDefinitionRepository(dataSource: DataSource)(implicit val profile
       updated = None,
       creator = repositoryContext.currentUser)
 
-    db.run(flowDefinitionTable += newDefinition).map(_ => FlowDefinitionDetails(
+    val existing = flowDefinitionTable.filter(_.id === flowDefinition.id).result.headOption
+
+    db.run(existing).flatMap {
+      case None => db.run(flowDefinitionTable += slickDefinition)
+      case Some(_) =>
+        val updated = flowDefinitionTable
+          .filter(_.id === flowDefinition.id).map(_.json)
+          .update(FlowDefinition.toJson(flowDefinition))
+        db.run(updated)
+    }.map(_ => FlowDefinitionDetails(
       flowDefinition.id,
-      version = Some(newDefinition.version),
-      source = Some(newDefinition.json),
-      created = Some(newDefinition.created)))
+      version = Some(slickDefinition.version),
+      source = Some(slickDefinition.json),
+      created = Some(slickDefinition.created)))
   }
 
   def definitionDetails(definition: SlickFlowDefinition): Option[FlowDefinitionDetails] =

--- a/slick/src/main/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepository.scala
+++ b/slick/src/main/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepository.scala
@@ -62,9 +62,8 @@ class SlickFlowScheduleRepository(dataSource: DataSource)(implicit val profile: 
   }
 
   override def getFlowSchedules(onlyEnabled: Boolean, flowId: Option[String])(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]] = {
-    val filteredSchedules = flowSchedulesTable
-      .filter(schedule => if (onlyEnabled) schedule.enabled === true else schedule.enabled === schedule.enabled)
-      .filter(schedule => flowId.map(schedule.flowDefinitionId === _).getOrElse(schedule.id === schedule.id))
+    val onlyEnabledSchedules = if (onlyEnabled) flowSchedulesTable.filter(_.enabled === true) else flowSchedulesTable
+    val filteredSchedules = onlyEnabledSchedules.filter(schedule => flowId.map(schedule.flowDefinitionId === _).getOrElse(schedule.id === schedule.id))
 
     db.run(filteredSchedules.result)
   }

--- a/slick/src/main/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepository.scala
+++ b/slick/src/main/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepository.scala
@@ -1,28 +1,16 @@
 package com.flowtick.sysiphos.slick
 
-import java.time.{ LocalDateTime, ZoneOffset }
+import java.util.UUID
 
 import com.flowtick.sysiphos.core.RepositoryContext
-import com.flowtick.sysiphos.scheduler.{ CronSchedule, FlowScheduleRepository, FlowScheduleStateStore }
+import com.flowtick.sysiphos.scheduler.{ FlowScheduleDetails, FlowScheduleRepository, FlowScheduleStateStore }
 import javax.sql.DataSource
 import org.slf4j.{ Logger, LoggerFactory }
 import slick.jdbc.JdbcProfile
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-final case class SlickCronSchedule(
-  id: String,
-  creator: String,
-  created: Long,
-  version: Long,
-  updated: Option[Long],
-  expression: String,
-  flowDefinitionId: String,
-  flowTaskId: Option[String],
-  nextDueDate: Option[Long],
-  enabled: Option[Boolean]) extends CronSchedule
-
-class SlickFlowScheduleRepository(dataSource: DataSource)(implicit val profile: JdbcProfile, executionContext: ExecutionContext) extends FlowScheduleRepository[SlickCronSchedule]
+class SlickFlowScheduleRepository(dataSource: DataSource)(implicit val profile: JdbcProfile, executionContext: ExecutionContext) extends FlowScheduleRepository
   with FlowScheduleStateStore {
 
   val log: Logger = LoggerFactory.getLogger(getClass)
@@ -31,40 +19,41 @@ class SlickFlowScheduleRepository(dataSource: DataSource)(implicit val profile: 
 
   val db: profile.backend.DatabaseDef = profile.backend.Database.forDataSource(dataSource, None, AsyncExecutor.default("flow-schedule-repository"))
 
-  class FlowSchedules(tag: Tag) extends Table[SlickCronSchedule](tag, "_FLOW_SCHEDULE") {
+  class FlowSchedules(tag: Tag) extends Table[FlowScheduleDetails](tag, "_FLOW_SCHEDULE") {
     def id = column[String]("_ID", O.PrimaryKey)
     def creator = column[String]("_CREATOR")
     def created = column[Long]("_CREATED")
     def version = column[Long]("_VERSION")
     def updated = column[Option[Long]]("_UPDATED")
-    def expression = column[String]("_EXPRESSION")
+    def expression = column[Option[String]]("_EXPRESSION")
     def flowDefinitionId = column[String]("_FLOW_DEFINITION_ID")
     def flowTaskId = column[Option[String]]("_FLOW_TASK_ID")
     def nextDueDate = column[Option[Long]]("_NEXT_DUE_DATE")
     def enabled = column[Option[Boolean]]("_ENABLED")
 
-    def * = (id, creator, created, version, updated, expression, flowDefinitionId, flowTaskId, nextDueDate, enabled) <> (SlickCronSchedule.tupled, SlickCronSchedule.unapply)
+    def * = (id, creator, created, version, updated, expression, flowDefinitionId, flowTaskId, nextDueDate, enabled) <> (FlowScheduleDetails.tupled, FlowScheduleDetails.unapply)
   }
 
   val flowSchedulesTable = TableQuery[FlowSchedules]
 
-  override def addFlowSchedule(
-    id: String,
-    expression: String,
+  def newId: String = UUID.randomUUID().toString
+
+  override def createFlowSchedule(
+    id: Option[String],
+    expression: Option[String],
     flowDefinitionId: String,
     flowTaskId: Option[String],
-    nextDueDate: Option[Long],
-    enabled: Option[Boolean])(implicit repositoryContext: RepositoryContext): Future[SlickCronSchedule] = {
-    val newSchedule = SlickCronSchedule(
-      id = id,
+    enabled: Option[Boolean])(implicit repositoryContext: RepositoryContext): Future[FlowScheduleDetails] = {
+    val newSchedule = FlowScheduleDetails(
+      id = id.getOrElse(newId),
       creator = repositoryContext.currentUser,
-      created = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC),
+      created = repositoryContext.epochSeconds,
       version = 0L,
       updated = None,
       expression = expression,
       flowDefinitionId = flowDefinitionId,
       flowTaskId,
-      nextDueDate,
+      None,
       enabled = enabled)
 
     db.run(flowSchedulesTable += newSchedule)
@@ -72,8 +61,8 @@ class SlickFlowScheduleRepository(dataSource: DataSource)(implicit val profile: 
       .map(_ => newSchedule)
   }
 
-  override def getFlowSchedules()(implicit repositoryContext: RepositoryContext): Future[Seq[SlickCronSchedule]] = {
-    db.run(flowSchedulesTable.result)
+  override def getFlowSchedules(onlyEnabled: Boolean)(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]] = {
+    db.run(flowSchedulesTable.filter(schedule => if (onlyEnabled) schedule.enabled === true else schedule.enabled === schedule.enabled).result)
   }
 
   override def setDueDate(flowScheduleId: String, dueDate: Long)(implicit repositoryContext: RepositoryContext): Future[Unit] = {
@@ -85,5 +74,27 @@ class SlickFlowScheduleRepository(dataSource: DataSource)(implicit val profile: 
     db.run(dueDateUpdate)
       .filter(_ > 0)
       .map(_ => ())
+  }
+
+  override def updateFlowSchedule(
+    id: String,
+    expression: Option[String],
+    enabled: Option[Boolean])(implicit repositoryContext: RepositoryContext): Future[FlowScheduleDetails] = {
+    db.run(flowSchedulesTable.filter(_.id === id).result.headOption).flatMap {
+      case Some(existing) =>
+        val newExpression = expression.orElse(existing.expression)
+        val newEnabled = enabled.orElse(existing.enabled)
+
+        val scheduleUpdate =
+          flowSchedulesTable
+            .filter(_.id === existing.id)
+            .map(flow => (flow.expression, flow.enabled, flow.nextDueDate, flow.version, flow.updated))
+            .update((newExpression, newEnabled, existing.nextDueDate, existing.version + 1, Some(repositoryContext.epochSeconds)))
+
+        db.run(scheduleUpdate)
+          .filter(_ > 0)
+          .map(_ => existing.copy(enabled = newEnabled, expression = newExpression))
+      case None => Future.failed(new IllegalArgumentException(s"could not find schedule with id $id"))
+    }
   }
 }

--- a/slick/src/main/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepository.scala
+++ b/slick/src/main/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepository.scala
@@ -61,8 +61,12 @@ class SlickFlowScheduleRepository(dataSource: DataSource)(implicit val profile: 
       .map(_ => newSchedule)
   }
 
-  override def getFlowSchedules(onlyEnabled: Boolean)(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]] = {
-    db.run(flowSchedulesTable.filter(schedule => if (onlyEnabled) schedule.enabled === true else schedule.enabled === schedule.enabled).result)
+  override def getFlowSchedules(onlyEnabled: Boolean, flowId: Option[String])(implicit repositoryContext: RepositoryContext): Future[Seq[FlowScheduleDetails]] = {
+    val filteredSchedules = flowSchedulesTable
+      .filter(schedule => if (onlyEnabled) schedule.enabled === true else schedule.enabled === schedule.enabled)
+      .filter(schedule => flowId.map(schedule.flowDefinitionId === _).getOrElse(schedule.id === schedule.id))
+
+    db.run(filteredSchedules.result)
   }
 
   override def setDueDate(flowScheduleId: String, dueDate: Long)(implicit repositoryContext: RepositoryContext): Future[Unit] = {

--- a/slick/src/test/scala/com/flowtick/sysiphos/slick/SlickFlowDefinitionRepositorySpec.scala
+++ b/slick/src/test/scala/com/flowtick/sysiphos/slick/SlickFlowDefinitionRepositorySpec.scala
@@ -19,7 +19,7 @@ class SlickFlowDefinitionRepositorySpec extends SlickSpec {
       CommandLineTask("foo", None, "ls -la"))
 
     Try(slickDefinitionRepository.getFlowDefinitions(this).futureValue).failed.foreach(_.printStackTrace())
-    slickDefinitionRepository.addFlowDefinition(simpleDefinition)(this).futureValue.source.map(FlowDefinition.fromJson) should be(Some(Right(simpleDefinition)))
+    slickDefinitionRepository.createOrUpdateFlowDefinition(simpleDefinition)(this).futureValue.source.map(FlowDefinition.fromJson) should be(Some(Right(simpleDefinition)))
     slickDefinitionRepository.getFlowDefinitions(this).futureValue should have size 1
   }
 }

--- a/slick/src/test/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepositorySpec.scala
+++ b/slick/src/test/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepositorySpec.scala
@@ -9,7 +9,7 @@ class SlickFlowScheduleRepositorySpec extends SlickSpec {
   "Slick Schedule Repository" should "create schedule" in new RepositoryContext {
     override def currentUser: String = "test-user"
 
-    slickScheduleRepository.addFlowSchedule("id", "expression", "definition_id", None, None, Some(true))(this).futureValue
+    slickScheduleRepository.createFlowSchedule("id", "expression", "definition_id", None, None, Some(true))(this).futureValue
   }
 
 }

--- a/slick/src/test/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepositorySpec.scala
+++ b/slick/src/test/scala/com/flowtick/sysiphos/slick/SlickFlowScheduleRepositorySpec.scala
@@ -9,7 +9,7 @@ class SlickFlowScheduleRepositorySpec extends SlickSpec {
   "Slick Schedule Repository" should "create schedule" in new RepositoryContext {
     override def currentUser: String = "test-user"
 
-    slickScheduleRepository.createFlowSchedule("id", "expression", "definition_id", None, None, Some(true))(this).futureValue
+    slickScheduleRepository.createFlowSchedule(Some("id"), Some("expression"), "definition_id", None, None)(this).futureValue
   }
 
 }


### PR DESCRIPTION
This extends the UI to allow creation and simple update of flow definitions and schedules, it also outlines the UI structure and the proper use of binding.scala